### PR TITLE
Support Go Modules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/processone/soundcloud
+
+go 1.9
+
+require golang.org/x/net v0.0.0-20190110200230-915654e7eabc

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/net v0.0.0-20190110200230-915654e7eabc h1:Yx9JGxI1SBhVLFjpAkWMaO1TF+xyqtHLjZpvQboJGiM=
+golang.org/x/net v0.0.0-20190110200230-915654e7eabc/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=


### PR DESCRIPTION
Like processone/mpg123#1, this patch adds basic support for [Go Modules], the new packaging standard that will be on by default Go 1.12. Experimental support is in Go 1.11 and the new module paths are supported in Go 1.9.7+ and Go 1.10.3+ in a read-only manner for backwards compatibility with all supported versions of Go.

Because this library is still below version 2, and has few external dependencies, the [`go.mod`] file is fairly simple. If you accept this PR, the only other thing to do would be to start using semver compatible tags and tag a release of this library that others can pin to (for example `v0.0.1` or `v1.0.0`).

The `go.sum` file in this patch is used to verify that when users download a particular version of your dependencies, they are seeing the same thing you saw (eg. in case of a Git hash collision, or a malicious package author that tries to change things after the fact).

Thank you for your consideration, I look forward to being able to pin to a specific version of these libraries.

[Go Modules]: https://github.com/golang/go/wiki/Modules
[`go.mod`]: https://tip.golang.org/cmd/go/#hdr-The_go_mod_file